### PR TITLE
feat: add observer api

### DIFF
--- a/src/app/home/Home.tsx
+++ b/src/app/home/Home.tsx
@@ -36,9 +36,40 @@ export default function Home() {
     }
 
   }, [mouseLocation]);
+  useEffect(() => {
+    const options = {
+      root: null,
+      rootMargin: '0px',
+      threshold: 0.5
+    }
 
-  
+    const callback = (entries: IntersectionObserverEntry[]) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          setActiveSection(entry.target.id);
+        }
+      });
+    }
 
+    const observer = new IntersectionObserver(callback, options);
+    const sections = ['about-me', 'experiences', 'projects', 'blog'];
+    sections.forEach(section => {
+      const element = document.getElementById(section);
+      if (element) {
+        observer.observe(element);
+      }
+    });
+
+    return () => {
+      sections.forEach(section => {
+        const element = document.getElementById(section);
+        if (element) {
+          observer.unobserve(element);
+        }
+      });
+    }
+
+  }, [])
 
   return (
     <div id="page" className="text-[#eaeaea9d] min-h-screen antialiased">


### PR DESCRIPTION
This pull request adds a new feature to the `Home` component in `src/app/home/Home.tsx` to dynamically track which section of the page is currently in view using the `IntersectionObserver` API.

### New Feature: Section Tracking with IntersectionObserver

* Added a `useEffect` hook to observe specific sections (`about-me`, `experiences`, `projects`, `blog`) on the page. When a section becomes visible (at least 50% in view), it updates the `activeSection` state with the section's ID.
* Implemented cleanup logic in the `useEffect` to unobserve the sections when the component is unmounted, ensuring proper resource management.